### PR TITLE
Wrong German translation for Graph

### DIFF
--- a/articles/cosmos-db/TOC.yml
+++ b/articles/cosmos-db/TOC.yml
@@ -31,7 +31,7 @@
       href: create-mongodb-dotnet.md
     - name: Java
       href: create-mongodb-java.md
-  - name: Grafik
+  - name: Graph
     items:
     - name: .NET
       href: create-graph-dotnet.md


### PR DESCRIPTION
Hi,
"Graph" should not be translated to "Grafik".
It is referred to as graph in german too.
"Grafik" means "graphic".

regards,
Clemens